### PR TITLE
Add max_input_tokens / max_output_tokens columns

### DIFF
--- a/.claude/skills/update-prices/SKILL.md
+++ b/.claude/skills/update-prices/SKILL.md
@@ -11,10 +11,11 @@ Update `src/data/llm_models.csv` with the latest pricing information from each p
 ## CSV Format
 
 ```
-provider,model,input_price,output_price,pricing_url
+provider,model,input_price,output_price,max_input_tokens,max_output_tokens,pricing_url
 ```
 
 - `input_price` / `output_price`: USD per 1M tokens
+- `max_input_tokens` / `max_output_tokens`: integer token counts (no commas, no `K`/`M` suffix). Use `-` when not applicable (e.g., image-generation models) or when the spec cannot be confirmed from official docs.
 - `pricing_url`: The provider's official pricing page URL
 - Use `-` for `output_price` when it does not apply (e.g., image generation models)
 
@@ -53,22 +54,35 @@ Use WebFetch to retrieve the latest pricing information from the following URLs 
   - If a promotional discount is currently active, record the regular (post-discount) list price, not the promo price
   - Skip models the page marks as "will be deprecated" — list only the current/replacement model names
 
-### 3. Update the CSV
+### 3. Fetch model specs (context window / max output tokens)
+
+Pricing pages do not include token limits for OpenAI, Anthropic, or Google — fetch from each provider's model documentation. DeepSeek's pricing page already contains them.
+
+- **OpenAI**: per-model pages under `https://developers.openai.com/api/docs/models/<model>` (e.g. `.../models/gpt-5.5`, `.../models/gpt-realtime-2`). Each page has "Context Window" and "Max Output Tokens". Image-generation models (`gpt-image-*`) do not publish these — use `-`.
+- **Anthropic**: the comparison tables on `https://docs.claude.com/en/docs/about-claude/models/overview` (which redirects to `https://platform.claude.com/docs/en/about-claude/models/overview`). Read the "Context window" and "Max output" rows. Both the "Latest models comparison" and "Legacy models" tables are needed to cover all non-deprecated models.
+- **Google**: per-model pages under `https://ai.google.dev/gemini-api/docs/models/<model-slug>` (e.g. `.../models/gemini-3.5-flash`, `.../models/gemini-2.5-pro`). Each page has "Input token limit" and "Output token limit". Note that slug conventions are inconsistent — some Preview variants and Live/Native-Audio models do not have individual pages; use `-` if not found.
+- **DeepSeek**: already on the pricing page — "Max context length" → `max_input_tokens`, "MAXIMUM" output → `max_output_tokens`.
+
+When a Preview variant lacks its own page, assume the same limits as the non-Preview variant of the same model family (and note this in the change report).
+
+### 4. Update the CSV
 
 Based on the fetched information, perform the following:
 
 - **Add new models**: Add models that exist on the official page but are missing from the CSV. Group models by provider.
 - **Update prices**: Update `input_price` / `output_price` for models whose prices have changed.
+- **Update token limits**: Update `max_input_tokens` / `max_output_tokens` when the spec changes.
 - **Remove deprecated or deleted models**: Remove rows for models that have been discontinued from the official page.
 - Maintain the existing provider order (OpenAI → Anthropic → Google → DeepSeek).
 - Order models within each provider according to the official page listing order.
 
-### 4. Report changes
+### 5. Report changes
 
 After the update is complete, report the following to the user:
 
-- List of newly added models
+- List of newly added models (include the token limits used and whether they were inferred from a sibling model)
 - List of models with price changes (old price → new price)
+- List of models with token-limit changes (old → new)
 - List of removed models
 - If no changes were made, report that as well
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_OPTIONS=--no-experimental-webstorage next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -8,7 +8,7 @@ interface ResultsTableProps {
   translations: TranslationStrings;
 }
 
-type SortKey = 'provider' | 'model' | 'inputPrice' | 'outputPrice' | 'estimatedCost';
+type SortKey = 'provider' | 'model' | 'inputPrice' | 'outputPrice' | 'maxInputTokens' | 'maxOutputTokens' | 'estimatedCost';
 type SortDirection = 'asc' | 'desc';
 
 export default function ResultsTable({ results, translations }: ResultsTableProps) {
@@ -44,6 +44,14 @@ export default function ResultsTable({ results, translations }: ResultsTableProp
       case 'outputPrice':
         aValue = a.output_price;
         bValue = b.output_price;
+        break;
+      case 'maxInputTokens':
+        aValue = a.max_input_tokens ?? -1;
+        bValue = b.max_input_tokens ?? -1;
+        break;
+      case 'maxOutputTokens':
+        aValue = a.max_output_tokens ?? -1;
+        bValue = b.max_output_tokens ?? -1;
         break;
       case 'estimatedCost':
         aValue = a.estimatedCost;
@@ -107,8 +115,8 @@ export default function ResultsTable({ results, translations }: ResultsTableProp
                   <span className="ml-1">{sortDirection === 'asc' ? '↑' : '↓'}</span>
                 )}
               </th>
-              <th 
-                scope="col" 
+              <th
+                scope="col"
                 className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer"
                 onClick={() => handleSort('outputPrice')}
               >
@@ -117,8 +125,28 @@ export default function ResultsTable({ results, translations }: ResultsTableProp
                   <span className="ml-1">{sortDirection === 'asc' ? '↑' : '↓'}</span>
                 )}
               </th>
-              <th 
-                scope="col" 
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer"
+                onClick={() => handleSort('maxInputTokens')}
+              >
+                {translations.resultsSection.maxInputTokens}
+                {sortKey === 'maxInputTokens' && (
+                  <span className="ml-1">{sortDirection === 'asc' ? '↑' : '↓'}</span>
+                )}
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer"
+                onClick={() => handleSort('maxOutputTokens')}
+              >
+                {translations.resultsSection.maxOutputTokens}
+                {sortKey === 'maxOutputTokens' && (
+                  <span className="ml-1">{sortDirection === 'asc' ? '↑' : '↓'}</span>
+                )}
+              </th>
+              <th
+                scope="col"
                 className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer"
                 onClick={() => handleSort('estimatedCost')}
               >
@@ -139,6 +167,8 @@ export default function ResultsTable({ results, translations }: ResultsTableProp
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{result.model}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">${result.input_price.toFixed(6)}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">${result.output_price.toFixed(6)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{result.max_input_tokens != null ? result.max_input_tokens.toLocaleString() : '—'}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{result.max_output_tokens != null ? result.max_output_tokens.toLocaleString() : '—'}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">${result.estimatedCost.toFixed(4)}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-blue-600">
                   <a href={result.pricing_url} target="_blank" rel="noopener noreferrer">

--- a/src/data/llm_models.csv
+++ b/src/data/llm_models.csv
@@ -1,40 +1,40 @@
-provider,model,input_price,output_price,pricing_url
-OpenAI,gpt-5.5,5.00,30.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-5.5-pro,30.00,180.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-5.4,2.50,15.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-5.4-mini,0.75,4.50,https://platform.openai.com/docs/pricing
-OpenAI,gpt-5.4-nano,0.20,1.25,https://platform.openai.com/docs/pricing
-OpenAI,gpt-5.4-pro,30.00,180.00,https://platform.openai.com/docs/pricing
-OpenAI,chat-latest,5.00,30.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-5.3-codex,1.75,14.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-realtime-2,4.00,24.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-realtime-1.5,4.00,16.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-realtime-mini,0.60,2.40,https://platform.openai.com/docs/pricing
-OpenAI,gpt-image-2,5.00,-,https://platform.openai.com/docs/pricing
-OpenAI,gpt-image-1.5,5.00,10.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-image-1-mini,2.00,-,https://platform.openai.com/docs/pricing
-OpenAI,o3-deep-research,5.00,20.00,https://platform.openai.com/docs/pricing
-OpenAI,o4-mini-deep-research,1.00,4.00,https://platform.openai.com/docs/pricing
-OpenAI,computer-use-preview,1.50,6.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-4o-transcribe,2.50,10.00,https://platform.openai.com/docs/pricing
-OpenAI,gpt-4o-mini-transcribe,1.25,5.00,https://platform.openai.com/docs/pricing
-Anthropic,Claude Opus 4.7,5.00,25.00,https://www.anthropic.com/pricing
-Anthropic,Claude Opus 4.6,5.00,25.00,https://www.anthropic.com/pricing
-Anthropic,Claude Opus 4.5,5.00,25.00,https://www.anthropic.com/pricing
-Anthropic,Claude Opus 4.1,15.00,75.00,https://www.anthropic.com/pricing
-Anthropic,Claude Sonnet 4.6,3.00,15.00,https://www.anthropic.com/pricing
-Anthropic,Claude Sonnet 4.5,3.00,15.00,https://www.anthropic.com/pricing
-Anthropic,Claude Haiku 4.5,1.00,5.00,https://www.anthropic.com/pricing
-Google,Gemini 3.5 Flash,1.50,9.00,https://ai.google.dev/pricing
-Google,Gemini 3.1 Flash-Lite,0.25,1.50,https://ai.google.dev/pricing
-Google,Gemini 3.1 Pro Preview,2.00,12.00,https://ai.google.dev/pricing
-Google,Gemini 3.1 Flash-Lite Preview,0.25,1.50,https://ai.google.dev/pricing
-Google,Gemini 3.1 Flash Live Preview,0.75,4.50,https://ai.google.dev/pricing
-Google,Gemini 3 Flash Preview,0.50,3.00,https://ai.google.dev/pricing
-Google,Gemini 2.5 Pro,1.25,10.00,https://ai.google.dev/pricing
-Google,Gemini 2.5 Flash,0.30,2.50,https://ai.google.dev/pricing
-Google,Gemini 2.5 Flash-Lite,0.10,0.40,https://ai.google.dev/pricing
-Google,Gemini 2.5 Flash-Lite Preview,0.10,0.40,https://ai.google.dev/pricing
-Google,Gemini 2.5 Flash Native Audio,0.50,2.00,https://ai.google.dev/pricing
-DeepSeek,deepseek-v4-flash,0.14,0.28,https://api-docs.deepseek.com/quick_start/pricing
-DeepSeek,deepseek-v4-pro,1.74,3.48,https://api-docs.deepseek.com/quick_start/pricing
+provider,model,input_price,output_price,max_input_tokens,max_output_tokens,pricing_url
+OpenAI,gpt-5.5,5.00,30.00,1050000,128000,https://platform.openai.com/docs/pricing
+OpenAI,gpt-5.5-pro,30.00,180.00,1050000,128000,https://platform.openai.com/docs/pricing
+OpenAI,gpt-5.4,2.50,15.00,1050000,128000,https://platform.openai.com/docs/pricing
+OpenAI,gpt-5.4-mini,0.75,4.50,400000,128000,https://platform.openai.com/docs/pricing
+OpenAI,gpt-5.4-nano,0.20,1.25,400000,128000,https://platform.openai.com/docs/pricing
+OpenAI,gpt-5.4-pro,30.00,180.00,1050000,128000,https://platform.openai.com/docs/pricing
+OpenAI,chat-latest,5.00,30.00,400000,128000,https://platform.openai.com/docs/pricing
+OpenAI,gpt-5.3-codex,1.75,14.00,400000,128000,https://platform.openai.com/docs/pricing
+OpenAI,gpt-realtime-2,4.00,24.00,128000,32000,https://platform.openai.com/docs/pricing
+OpenAI,gpt-realtime-1.5,4.00,16.00,32000,4096,https://platform.openai.com/docs/pricing
+OpenAI,gpt-realtime-mini,0.60,2.40,32000,4096,https://platform.openai.com/docs/pricing
+OpenAI,gpt-image-2,5.00,-,-,-,https://platform.openai.com/docs/pricing
+OpenAI,gpt-image-1.5,5.00,10.00,-,-,https://platform.openai.com/docs/pricing
+OpenAI,gpt-image-1-mini,2.00,-,-,-,https://platform.openai.com/docs/pricing
+OpenAI,o3-deep-research,5.00,20.00,200000,100000,https://platform.openai.com/docs/pricing
+OpenAI,o4-mini-deep-research,1.00,4.00,200000,100000,https://platform.openai.com/docs/pricing
+OpenAI,computer-use-preview,1.50,6.00,8192,1024,https://platform.openai.com/docs/pricing
+OpenAI,gpt-4o-transcribe,2.50,10.00,16000,2000,https://platform.openai.com/docs/pricing
+OpenAI,gpt-4o-mini-transcribe,1.25,5.00,16000,2000,https://platform.openai.com/docs/pricing
+Anthropic,Claude Opus 4.7,5.00,25.00,1000000,128000,https://www.anthropic.com/pricing
+Anthropic,Claude Opus 4.6,5.00,25.00,1000000,128000,https://www.anthropic.com/pricing
+Anthropic,Claude Opus 4.5,5.00,25.00,200000,64000,https://www.anthropic.com/pricing
+Anthropic,Claude Opus 4.1,15.00,75.00,200000,32000,https://www.anthropic.com/pricing
+Anthropic,Claude Sonnet 4.6,3.00,15.00,1000000,64000,https://www.anthropic.com/pricing
+Anthropic,Claude Sonnet 4.5,3.00,15.00,200000,64000,https://www.anthropic.com/pricing
+Anthropic,Claude Haiku 4.5,1.00,5.00,200000,64000,https://www.anthropic.com/pricing
+Google,Gemini 3.5 Flash,1.50,9.00,1048576,65536,https://ai.google.dev/pricing
+Google,Gemini 3.1 Flash-Lite,0.25,1.50,1048576,65536,https://ai.google.dev/pricing
+Google,Gemini 3.1 Pro Preview,2.00,12.00,1048576,65536,https://ai.google.dev/pricing
+Google,Gemini 3.1 Flash-Lite Preview,0.25,1.50,1048576,65536,https://ai.google.dev/pricing
+Google,Gemini 3.1 Flash Live Preview,0.75,4.50,-,-,https://ai.google.dev/pricing
+Google,Gemini 3 Flash Preview,0.50,3.00,1048576,65536,https://ai.google.dev/pricing
+Google,Gemini 2.5 Pro,1.25,10.00,1048576,65536,https://ai.google.dev/pricing
+Google,Gemini 2.5 Flash,0.30,2.50,1048576,65536,https://ai.google.dev/pricing
+Google,Gemini 2.5 Flash-Lite,0.10,0.40,1048576,65536,https://ai.google.dev/pricing
+Google,Gemini 2.5 Flash-Lite Preview,0.10,0.40,1048576,65536,https://ai.google.dev/pricing
+Google,Gemini 2.5 Flash Native Audio,0.50,2.00,-,-,https://ai.google.dev/pricing
+DeepSeek,deepseek-v4-flash,0.14,0.28,1000000,384000,https://api-docs.deepseek.com/quick_start/pricing
+DeepSeek,deepseek-v4-pro,1.74,3.48,1000000,384000,https://api-docs.deepseek.com/quick_start/pricing

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -14,6 +14,8 @@
     "model": "Model",
     "inputPrice": "Input Price (per 1K tokens)",
     "outputPrice": "Output Price (per 1K tokens)",
+    "maxInputTokens": "Max Input Tokens",
+    "maxOutputTokens": "Max Output Tokens",
     "estimatedCost": "Estimated Cost (USD)",
     "pricingLink": "Pricing Details",
     "inputTokens": "Input Tokens",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -14,6 +14,8 @@
     "model": "モデル",
     "inputPrice": "入力価格（1,000トークンあたり）",
     "outputPrice": "出力価格（1,000トークンあたり）",
+    "maxInputTokens": "最大入力トークン数",
+    "maxOutputTokens": "最大出力トークン数",
     "estimatedCost": "推定コスト（USD）",
     "pricingLink": "価格詳細",
     "inputTokens": "入力トークン数",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,8 @@ export interface LLMModel {
   model: string;
   input_price: number;
   output_price: number;
+  max_input_tokens: number | null;
+  max_output_tokens: number | null;
   pricing_url: string;
 }
 
@@ -31,6 +33,8 @@ export interface TranslationStrings {
     model: string;
     inputPrice: string;
     outputPrice: string;
+    maxInputTokens: string;
+    maxOutputTokens: string;
     estimatedCost: string;
     pricingLink: string;
     inputTokens: string;

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -5,10 +5,16 @@ import modelDataRaw from '@/data/llm_models.csv';
 // Store CSV loaded as string in variable
 const modelData = modelDataRaw as string;
 
+function parseTokenLimit(value: string): number | null {
+  if (!value || value === '-') return null;
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
 export async function getModelData(): Promise<LLMModel[]> {
   try {
     // Parse and return CSV data
-    const lines = modelData.trim().split('\n');    
+    const lines = modelData.trim().split('\n');
     return lines.slice(1).map(line => {
       const values = line.split(',');
       return {
@@ -16,11 +22,13 @@ export async function getModelData(): Promise<LLMModel[]> {
         model: values[1],
         input_price: parseFloat(values[2]),
         output_price: parseFloat(values[3]),
-        pricing_url: values[4]
+        max_input_tokens: parseTokenLimit(values[4]),
+        max_output_tokens: parseTokenLimit(values[5]),
+        pricing_url: values[6]
       };
     });
   } catch (error) {
     console.error('Error loading model data:', error);
     return [];
   }
-} 
+}


### PR DESCRIPTION

<img width="1553" height="152" alt="image" src="https://github.com/user-attachments/assets/da1b42d0-6997-47a0-8b01-1aa5da7a77f5" />


## Summary
- Add \`max_input_tokens\` and \`max_output_tokens\` columns to \`llm_models.csv\`
- Populate values from each provider's model docs:
  - **OpenAI**: developers.openai.com per-model pages
  - **Anthropic**: docs.claude.com models overview
  - **Google**: ai.google.dev per-model pages
  - **DeepSeek**: pricing page (the same URL already had context info)
- Update \`LLMModel\` type, CSV parser, and results table to display the new columns
- Add i18n labels: "Max Input Tokens" / "最大入力トークン数", "Max Output Tokens" / "最大出力トークン数"
- Use \`-\` for image-generation models and a few Live/audio models whose specs aren't exposed in official docs

## Test plan
- [ ] \`npm run lint\` passes (only existing warning remains)
- [ ] \`npx tsc --noEmit\` passes
- [ ] Verify new columns render in the results table
- [ ] Verify sorting by max_input_tokens / max_output_tokens works
- [ ] Verify \`—\` is shown for rows with \`-\` in the CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)