### PR TITLE
Fix tokenizer init so Japanese (and all) input is counted correctly

### DIFF
--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -1,15 +1,17 @@
-import { Tiktoken } from 'js-tiktoken';
+import type { Tiktoken } from 'js-tiktoken/lite';
 
 let tokenizer: Tiktoken | null = null;
 
 // Initialize class for token calculation
 async function initTokenizer() {
   if (!tokenizer) {
-    const { Tiktoken } = await import('js-tiktoken');
-    tokenizer = new Tiktoken(
-      // cl100k_base is the encoding used by latest models like GPT-4, GPT-3.5-Turbo
-      'cl100k_base'
-    );
+    const [{ Tiktoken }, { default: cl100k_base }] = await Promise.all([
+      import('js-tiktoken/lite'),
+      import('js-tiktoken/ranks/cl100k_base'),
+    ]);
+    // cl100k_base is the encoding used by GPT-4 / GPT-3.5-Turbo.
+    // The constructor expects a TiktokenBPE rank object, not the encoding name.
+    tokenizer = new Tiktoken(cl100k_base);
   }
   return tokenizer;
 }


### PR DESCRIPTION
## Summary
- `new Tiktoken('cl100k_base')` was passing the encoding **name** to a constructor that expects a `TiktokenBPE` rank object, so the constructor threw on every call.
- `countTokens` swallowed the error and fell back to `Math.ceil(text.split(/\s+/).length * 1.3)`. Japanese input has no whitespace, so any length of Japanese text collapsed to **2 tokens**. English was also off — it returned a word-count heuristic, not real tiktoken counts.
- Load `cl100k_base` ranks via `js-tiktoken/lite` + `js-tiktoken/ranks/cl100k_base` and pass them into the constructor. Lite + a single ranks file keeps only `cl100k_base` in the bundle.

Example (宮沢賢治の一節):
- Before: **2 tokens** (fallback)
- After: **79 tokens** (cl100k_base)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint src/utils/tokenizer.ts` passes
- [x] Standalone reproduction: 79 tokens for the sample Japanese passage
- [ ] Manually paste Japanese and English into the dev UI and confirm token counts look reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)