### PR TITLE
Update LLM prices (2026-06-10): Anthropic Fable 5 / Mythos 5 / Opus 4.8, DeepSeek v4-pro drop

### DIFF
--- a/src/data/llm_models.csv
+++ b/src/data/llm_models.csv
@@ -18,10 +18,12 @@ OpenAI,o4-mini-deep-research,1.00,4.00,200000,100000,https://platform.openai.com
 OpenAI,computer-use-preview,1.50,6.00,8192,1024,https://platform.openai.com/docs/pricing
 OpenAI,gpt-4o-transcribe,2.50,10.00,16000,2000,https://platform.openai.com/docs/pricing
 OpenAI,gpt-4o-mini-transcribe,1.25,5.00,16000,2000,https://platform.openai.com/docs/pricing
+Anthropic,Claude Fable 5,10.00,50.00,1000000,128000,https://www.anthropic.com/pricing
+Anthropic,Claude Mythos 5,10.00,50.00,1000000,128000,https://www.anthropic.com/pricing
+Anthropic,Claude Opus 4.8,5.00,25.00,1000000,128000,https://www.anthropic.com/pricing
 Anthropic,Claude Opus 4.7,5.00,25.00,1000000,128000,https://www.anthropic.com/pricing
 Anthropic,Claude Opus 4.6,5.00,25.00,1000000,128000,https://www.anthropic.com/pricing
 Anthropic,Claude Opus 4.5,5.00,25.00,200000,64000,https://www.anthropic.com/pricing
-Anthropic,Claude Opus 4.1,15.00,75.00,200000,32000,https://www.anthropic.com/pricing
 Anthropic,Claude Sonnet 4.6,3.00,15.00,1000000,64000,https://www.anthropic.com/pricing
 Anthropic,Claude Sonnet 4.5,3.00,15.00,200000,64000,https://www.anthropic.com/pricing
 Anthropic,Claude Haiku 4.5,1.00,5.00,200000,64000,https://www.anthropic.com/pricing
@@ -37,4 +39,4 @@ Google,Gemini 2.5 Flash-Lite,0.10,0.40,1048576,65536,https://ai.google.dev/prici
 Google,Gemini 2.5 Flash-Lite Preview,0.10,0.40,1048576,65536,https://ai.google.dev/pricing
 Google,Gemini 2.5 Flash Native Audio,0.50,2.00,-,-,https://ai.google.dev/pricing
 DeepSeek,deepseek-v4-flash,0.14,0.28,1000000,384000,https://api-docs.deepseek.com/quick_start/pricing
-DeepSeek,deepseek-v4-pro,1.74,3.48,1000000,384000,https://api-docs.deepseek.com/quick_start/pricing
+DeepSeek,deepseek-v4-pro,0.435,0.87,1000000,384000,https://api-docs.deepseek.com/quick_start/pricing


### PR DESCRIPTION
## 概要
公式価格ページから `src/data/llm_models.csv` を更新しました（`/update-prices`）。

## 変更内容

### 新規追加（Anthropic）
| モデル | input | output | max_input | max_output |
|---|---|---|---|---|
| Claude Fable 5 | \$10 | \$50 | 1,000,000 | 128,000 |
| Claude Mythos 5 | \$10 | \$50 | 1,000,000 | 128,000 |
| Claude Opus 4.8 | \$5 | \$25 | 1,000,000 | 128,000 |

- Mythos 5 は Project Glasswing 限定提供（招待制）だが価格表に掲載のため収録
- トークン上限は公式 models overview の比較表で確認

### 価格変更
| モデル | 旧 (in/out) | 新 (in/out) |
|---|---|---|
| deepseek-v4-pro | \$1.74 / \$3.48 | **\$0.435 / \$0.87** |

- DeepSeek 価格ページを2回確認し、プロモ割引ではなく通常の定価であることを確認
- https://gigazine.net/news/20260526-deepseek-v4-pro-pricing/

### 削除
- Claude Opus 4.1（公式で deprecated、2026/08/05 廃止予定）

### 変更なし
- OpenAI: 全モデル一致
- Google: 掲載モデルの価格一致。新モデル Gemini 3.5 Live Translate は audio レートのみで text レート不明のため未収録

🤖 Generated with [Claude Code](https://claude.com/claude-code)