### PR TITLE
Auto-deploy to GitHub Pages on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Allow pushing to the gh-pages branch
+permissions:
+  contents: write
+
+# Prevent overlapping deploys
+concurrency:
+  group: deploy-gh-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static site
+        run: npm run build
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          publish_branch: gh-pages


### PR DESCRIPTION
## 概要
main への push（PRマージ含む）をトリガーに、GitHub Pages へ自動デプロイする GitHub Actions ワークフローを追加します。

## 動作
- トリガー: `push` to `main`（PRマージ時に発火）＋ 手動実行（`workflow_dispatch`）
- `npm ci` → `npm run build`（Next.js static export を `docs/` に生成）
- `peaceiris/actions-gh-pages` で `docs/` を `gh-pages` ブランチへ publish

## 補足
- 既存の手動 `npm run deploy` と同じ成果物・同じ公開ブランチ（`gh-pages`）を使うため、**Pages の設定変更は不要**です（現状のソース: `gh-pages` ブランチ）。
- `GITHUB_TOKEN` を使用するため追加 Secret は不要。
- `concurrency` で多重デプロイを防止。

マージ後、次回以降の main 更新で自動デプロイされます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)