### PR TITLE
Debounce token calculation to ease typing

### DIFF
--- a/src/components/InputForm.tsx
+++ b/src/components/InputForm.tsx
@@ -16,9 +16,13 @@ export default function InputForm({ onCalculate, translations, inputTokens = 0, 
   const [outputText, setOutputText] = useState<string>('');
   const [requestCount, setRequestCount] = useState<number>(1);
 
-  // Automatically run calculation whenever input changes
+  // Automatically run calculation after the user stops typing for 1 second (debounce)
   useEffect(() => {
-    onCalculate(inputText, outputText, requestCount);
+    const timer = setTimeout(() => {
+      onCalculate(inputText, outputText, requestCount);
+    }, 1000);
+
+    return () => clearTimeout(timer);
   }, [inputText, outputText, requestCount]); // Removed onCalculate from dependency array
 
   return (


### PR DESCRIPTION
## Summary

Token calculation was running on every keystroke, making typing laggy and stressful. This adds a 1-second debounce so the calculation only runs after the user stops typing.

## Changes

- `src/components/InputForm.tsx`: Wrap the `onCalculate` call in the `useEffect` with a `setTimeout` (1000ms) and clear it on cleanup, so the heavy per-model token counting fires once after input settles instead of on each character.

## Verification

- ✅ `tsc --noEmit` — no errors
- ✅ `next lint` — no warnings/errors
- ✅ `next build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)